### PR TITLE
Added thread config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ use std::sync::{Arc, Mutex, Condvar};
 /// the `Scope` type directly.
 #[derive(Clone)]
 pub struct Pool {
-    queue: Arc<MsQueue<PoolMessage>>,
-    wait: Arc<WaitGroup>
+    wait: Arc<WaitGroup>,
+    inner: Arc<PoolInner>
 }
 
 impl Pool {
@@ -51,6 +51,42 @@ impl Pool {
         pool
     }
 
+    /// Create a new Pool with `size` threads and given thread config.
+    ///
+    /// If `size` is zero, no threads will be spawned. Threads can
+    /// be added later via `expand`.
+    ///
+    /// NOTE: Since Pool can be freely cloned, it does not represent a unique
+    /// handle to the thread pool. As a consequence, the thread pool is not
+    /// automatically shut down; you must explicitly call `Pool::shutdown` to
+    /// shut down the pool.
+    #[inline]
+    pub fn new_with_thread_config(size: usize, thread_config: ThreadConfig) -> Pool {
+        // Create an empty pool with configuration.
+        let pool = Pool::with_thread_config(thread_config);
+
+        // Start the requested number of threads.
+        for _ in 0..size { pool.expand(); }
+
+        pool
+    }
+
+    /// Create an empty Pool, with no threads, with given thread config.
+    ///
+    /// Note that no jobs will run until `expand` is called and
+    /// worker threads are added.
+    #[inline]
+    pub fn with_thread_config(thread_config: ThreadConfig) -> Pool {
+        Pool {
+            wait: Arc::new(WaitGroup::new()),
+            inner: Arc::new(PoolInner {
+                queue: MsQueue::new(),
+                thread_config: thread_config,
+                thread_counter: AtomicUsize::new(1)
+            })
+        }
+    }
+
     /// Create an empty Pool, with no threads.
     ///
     /// Note that no jobs will run until `expand` is called and
@@ -58,8 +94,12 @@ impl Pool {
     #[inline]
     pub fn empty() -> Pool {
         Pool {
-            queue: Arc::new(MsQueue::new()),
-            wait: Arc::new(WaitGroup::new())
+            wait: Arc::new(WaitGroup::new()),
+            inner: Arc::new(PoolInner {
+                queue: MsQueue::new(),
+                thread_config: ThreadConfig::new(),
+                thread_counter: AtomicUsize::new(1)
+            })
         }
     }
 
@@ -108,7 +148,7 @@ impl Pool {
     #[inline]
     pub fn shutdown(&self) {
         // Start the shutdown process.
-        self.queue.push(PoolMessage::Quit);
+        self.inner.queue.push(PoolMessage::Quit);
 
         // Wait for it to complete.
         self.wait.join()
@@ -124,8 +164,22 @@ impl Pool {
         // Submit the new thread to the thread waitgroup.
         pool.wait.submit();
 
+        let thread_number = self.inner.thread_counter.fetch_add(1, Ordering::SeqCst);
+
+        // Deal with thread configuration.
+        let mut builder = thread::Builder::new();
+        if self.inner.thread_config.name_prefix.is_some() {
+            let name = format!("{}{}",
+                               self.inner.thread_config.name_prefix.as_ref().unwrap(),
+                               thread_number);
+            builder = builder.name(name);
+        }
+        if self.inner.thread_config.stack_size.is_some() {
+            builder = builder.stack_size(self.inner.thread_config.stack_size.unwrap());
+        }
+
         // Start the actual thread.
-        thread::spawn(move || pool.run_thread());
+        builder.spawn(move || pool.run_thread()).unwrap();
     }
 
     fn run_thread(self) {
@@ -133,11 +187,11 @@ impl Pool {
         let mut thread_sentinel = ThreadSentinel(Some(self.clone()));
 
         loop {
-            match self.queue.pop() {
+            match self.inner.queue.pop() {
                 // On Quit, repropogate and quit.
                 PoolMessage::Quit => {
                     // Repropogate the Quit message to other threads.
-                    self.queue.push(PoolMessage::Quit);
+                    self.inner.queue.push(PoolMessage::Quit);
 
                     // Cancel the thread sentinel so we don't panic waiting
                     // shutdown threads, and don't restart the thread.
@@ -154,6 +208,49 @@ impl Pool {
                     sentinel.cancel();
                 }
             }
+        }
+    }
+}
+
+struct PoolInner {
+    queue: MsQueue<PoolMessage>,
+    thread_config: ThreadConfig,
+    thread_counter: AtomicUsize
+}
+
+/// Thread configuration. Provides detailed control over the properties and behavior of new
+/// threads.
+#[derive(Clone)]
+pub struct ThreadConfig {
+    name_prefix: Option<String>,
+    stack_size: Option<usize>,
+}
+
+impl ThreadConfig {
+    /// Generates the base configuration for spawning a thread, from which configuration methods
+    /// can be chained.
+    pub fn new() -> ThreadConfig {
+        ThreadConfig {
+            name_prefix: None,
+            stack_size: None,
+        }
+    }
+
+    /// Name prefix of spawned threads. Thread number will be appended to this prefix to form each
+    /// thread's unique name. Currently the name is used for identification only in panic
+    /// messages.
+    pub fn name_prefix<S: Into<String>>(self, name_prefix: S) -> ThreadConfig {
+        ThreadConfig {
+            name_prefix: Some(name_prefix.into()),
+            ..self
+        }
+    }
+
+    /// Sets the size of the stack for the new thread.
+    pub fn stack_size(self, stack_size: usize) -> ThreadConfig {
+        ThreadConfig {
+            stack_size: Some(stack_size),
+            ..self
         }
     }
 }
@@ -210,7 +307,7 @@ impl<'scope> Scope<'scope> {
         };
 
         // Submit the task to be executed.
-        self.pool.queue.push(PoolMessage::Task(task, self.wait.clone()));
+        self.pool.inner.queue.push(PoolMessage::Task(task, self.wait.clone()));
     }
 
     /// Add a job to this scope which itself will get access to the scope.
@@ -418,7 +515,7 @@ mod test {
     use std::time::Duration;
     use std::thread::sleep;
 
-    use {Pool, Scope};
+    use {Pool, Scope, ThreadConfig};
 
     #[test]
     fn test_simple_use() {
@@ -625,6 +722,30 @@ mod test {
             }
 
             panic!();
+        });
+    }
+
+    #[test]
+    fn test_no_thread_config() {
+        let pool = Pool::new(1);
+
+        pool.scoped(|scope| {
+            scope.execute(|| {
+                assert!(::std::thread::current().name().is_none());
+            });
+        });
+    }
+
+    #[test]
+    fn test_with_thread_config() {
+        let config = ThreadConfig::new().name_prefix("pool-");
+
+        let pool = Pool::new_with_thread_config(1, config);
+
+        pool.scoped(|scope| {
+            scope.execute(|| {
+                assert_eq!(::std::thread::current().name().unwrap(), "pool-1");
+            });
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,7 @@ impl Pool {
         // Create an empty pool with configuration.
         let pool = Pool {
             wait: Arc::new(WaitGroup::new()),
-            inner: Arc::new(PoolInner {
-                queue: MsQueue::new(),
-                thread_config: thread_config,
-                thread_counter: AtomicUsize::new(1)
-            })
+            inner: Arc::new(PoolInner::with_thread_config(thread_config))
         };
 
         // Start the requested number of threads.
@@ -86,11 +82,7 @@ impl Pool {
     pub fn empty() -> Pool {
         Pool {
             wait: Arc::new(WaitGroup::new()),
-            inner: Arc::new(PoolInner {
-                queue: MsQueue::new(),
-                thread_config: ThreadConfig::new(),
-                thread_counter: AtomicUsize::new(1)
-            })
+            inner: Arc::new(PoolInner::default())
         }
     }
 
@@ -207,9 +199,25 @@ struct PoolInner {
     thread_counter: AtomicUsize
 }
 
+impl PoolInner {
+    fn with_thread_config(thread_config: ThreadConfig) -> Self {
+        PoolInner { thread_config: thread_config, ..Self::default() }
+    }
+}
+
+impl Default for PoolInner {
+    fn default() -> Self {
+        PoolInner {
+            queue: MsQueue::new(),
+            thread_config: ThreadConfig::default(),
+            thread_counter: AtomicUsize::new(1)
+        }
+    }
+}
+
 /// Thread configuration. Provides detailed control over the properties and behavior of new
 /// threads.
-#[derive(Clone)]
+#[derive(Default)]
 pub struct ThreadConfig {
     prefix: Option<String>,
     stack_size: Option<usize>,


### PR DESCRIPTION
This allows to give names to pool threads, which is particularly handy
for logging, and set thead's stack size. Also refactored some fields in
`PoolInner` struct to limit Arc cloning here and there.

Don't know if `ThreadConfig` is a fortunate name, the closest thing to this in Java is called `ThreadFactory`, but here this struct doesn't create threads on its own.

Also maybe methods like `new_with_thread_config` and `with_thread_config` can be named better.
